### PR TITLE
Fixing minor typos to reflect the guidelines & intention correctly.

### DIFF
--- a/1_Storyboard.md
+++ b/1_Storyboard.md
@@ -328,7 +328,7 @@ add an image view object to our view.
 
 {x: add_icon}
 Drag an image view from the object library and drop it onto your entry view. Set a
-height constraint of 13 points and a width constraint of 18 points in the pin menu. 
+height constraint of 18 points and a width constraint of 13 points in the pin menu. 
 
 {x: add_background_image}
 Change image property of our new image view to the pencil icon, which can be 

--- a/2_EntryFormController.md
+++ b/2_EntryFormController.md
@@ -315,7 +315,7 @@ statement but before view.addSubview(picker) add the following:
 ~~~language-swift
 var offset = 21
 
-for (index, feeling) in enumerate(AppHelper.properties.feelings)
+for (index, feeling) in enumerate(feelings)
   {
     let button = UIButton()
     button.frame = CGRect(x: 13, y: offset, width: 260, height: 43)
@@ -381,6 +381,9 @@ func openPicker()
         self.picker.alpha = 1
       },
       completion: { finished in
+        if (finished) {
+            self.picker.hidden = false
+        }
       }
     )
   }

--- a/2_EntryFormController.md
+++ b/2_EntryFormController.md
@@ -175,7 +175,7 @@ property set to true by default. However, when we initialize a new UIImageView
 object in code, the userInteractionEnabled property is set to false by default. We actually
 could have drawn the picker in our Main.storyboard file using interface builder and 
 set our properties attributes inspector. The reason we did not draw our dropdown
-in the interface builder is because we are going to be problematically creating 
+in the interface builder is because we are going to be programatically creating 
 what's called <i>subviews</i> of the button.
 
 {video: flourish_subview_superview}


### PR DESCRIPTION
Two minor fixes.
- The height and width were interchanged in the documentation leaving resulting image stretched.
- Programatically was typed as problematically, which obscured the intention.
